### PR TITLE
RDCC-2743 : Fixing the CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,6 +333,8 @@ dependencies {
     compile group: 'javax.el', name: 'javax.el-api', version: '3.0.0'
 
     compile group:"org.yaml", name: "snakeyaml", version:"1.27"
+    //Fix for CVE-2021-29425
+    implementation 'commons-io:commons-io:2.8.0'
 
     compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDCC-2743


### Change description ###
RDCC-2743 : Fixing the CVE-2021-29425


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
