### PR TITLE
 fix: patch log4j to the 2.16.0 in all applications to fix CVE-2021-45046

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def versions = [
         launchDarklySdk    : "5.2.3",
         junit              : '5.8.1',
         junitPlatform      : '1.8.1',
-        log4j              : '2.15.0'
+        log4j              : '2.16.0'
 
 ]
 


### PR DESCRIPTION
JIRA link
https://tools.hmcts.net/jira/browse/RDCC-3799

Change description
patch log4j to the 2.16.0 in all applications to fix CVE-2021-45046

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No