### PR TITLE
fix: CVE-2021-45105 by upgrading log4j to 2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ def versions = [
         launchDarklySdk    : "5.2.3",
         junit              : '5.8.1',
         junitPlatform      : '1.8.1',
-        log4j              : '2.16.0'
+        log4j              : '2.17.0'
 
 ]
 


### PR DESCRIPTION
### JIRA link  ###

https://tools.hmcts.net/jira/browse/RDCC-3820

### Change description ###

upgrading log4j to 2.17.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```