### PR TITLE
RDCC-5534: Upgrading `launchdarkly-java-server-sdk` & `snakeyaml`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ def versions = [
         springHystrix      : '2.2.8.RELEASE',
         springfoxSwagger   : '2.9.2',
         pact_version       : '4.1.7',
-        launchDarklySdk    : "5.8.1",
+        launchDarklySdk    : "5.10.2",
         junit              : '5.8.1',
         junitPlatform      : '1.8.1',
         jackson            : '2.13.1',
@@ -382,7 +382,7 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: versions.log4j
     implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.6.2'
     //Fix for CVE-2022-25857
-    implementation group:"org.yaml", name: "snakeyaml", version:"1.31"
+    implementation group:"org.yaml", name: "snakeyaml", version:"1.33"
     //Fix for CVE-2021-29425
     implementation 'commons-io:commons-io:2.11.0'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5534

### Change description ###

Upgrading `launchdarkly-java-server-sdk` & `snakeyaml` to fix CVE-2022-38752

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
