### PR TITLE
Addresses CVE-2023-20863

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ def versions = [
         junitPlatform      : '1.9.2',
         jackson            : '2.14.0-rc1',
         log4j              : '2.17.1',
-        springVersion      : '5.3.26',
+        springVersion      : '5.3.27',
         logback            : '1.2.10',
         feign              : '3.8.0',
         bytebuddy          : '1.12.7',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-264

### Change description ###

Addresses nightly build failure due to CVE-2023-20863

Mitigated in spring 5.3.27
https://spring.io/security/cve-2023-20863



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
