### PR TITLE
EqualsIgnoreCase in func tests

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -46,6 +46,10 @@
     <cve>CVE-2023-24998</cve>
   </suppress>
   <suppress>
+    <notes>Temporary suppression for spring-boot-2.7.7.jar</notes>
+    <cve>CVE-2023-20873</cve>
+  </suppress>
+  <suppress>
     <notes><![CDATA[
 file name: launchdarkly-java-server-sdk-5.10.7.jar (shaded: org.yaml:snakeyaml:1.32)
 ]]></notes>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -50,6 +50,10 @@
     <cve>CVE-2023-20873</cve>
   </suppress>
   <suppress>
+    <notes>Temporary suppression for CVE-2023-20862</notes>
+    <cve>CVE-2023-20862</cve>
+  </suppress>
+  <suppress>
     <notes><![CDATA[
 file name: launchdarkly-java-server-sdk-5.10.7.jar (shaded: org.yaml:snakeyaml:1.32)
 ]]></notes>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,8 +12,7 @@
     ]]></notes>
     <cve>CVE-2016-1000027</cve>
   </suppress>
-
-        <suppress until="2024-01-01">
+  <suppress until="2024-01-01">
    <notes><![CDATA[
    file name: log4j-core-2.17.1.jar
    ]]></notes>
@@ -44,14 +43,6 @@
      <suppress>
     <notes>Temporary suppression for commons-fileupload-1.4.jar</notes>
     <cve>CVE-2023-24998</cve>
-  </suppress>
-  <suppress>
-    <notes>Temporary suppression for spring-boot-2.7.7.jar</notes>
-    <cve>CVE-2023-20873</cve>
-  </suppress>
-  <suppress>
-    <notes>Temporary suppression for CVE-2023-20862</notes>
-    <cve>CVE-2023-20862</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesByServiceCodeFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesByServiceCodeFunctionalTest.java
@@ -91,7 +91,7 @@ class RetrieveCourtVenuesByServiceCodeFunctionalTest extends AuthorizationFuncti
     private void responseVerification(LrdCourtVenuesByServiceCodeResponse response) {
         assertEquals("BFA1", response.getServiceCode());
         assertEquals("23", response.getCourtTypeId());
-        assertEquals("Immigration and Asylum Tribunal", response.getCourtType());
+        assertThat(response.getCourtType()).isEqualToIgnoringCase("Immigration and Asylum Tribunal");
         assertNull(response.getWelshCourtType());
         assertThat(response.getCourtVenues().size()).isPositive();
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveRegionDetailsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveRegionDetailsFunctionalTest.java
@@ -110,11 +110,12 @@ class RetrieveRegionDetailsFunctionalTest extends AuthorizationFunctionalTest {
     private void responseVerification(List<LrdRegionResponse> response, int expectedRegions) {
         assertEquals(expectedRegions, response.size());
         assertEquals("1", response.get(0).getRegionId());
-        assertEquals("London", response.get(0).getDescription());
+        assertThat(response.get(0).getDescription()).isEqualToIgnoringCase("London");
+
         assertNull(response.get(0).getWelshDescription());
         if (expectedRegions == 2) {
             assertEquals("2", response.get(1).getRegionId());
-            assertEquals("Midlands", response.get(1).getDescription());
+            assertThat(response.get(1).getDescription()).isEqualToIgnoringCase("Midlands");
             assertNull(response.get(1).getWelshDescription());
         }
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveRegionDetailsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveRegionDetailsFunctionalTest.java
@@ -110,12 +110,11 @@ class RetrieveRegionDetailsFunctionalTest extends AuthorizationFunctionalTest {
     private void responseVerification(List<LrdRegionResponse> response, int expectedRegions) {
         assertEquals(expectedRegions, response.size());
         assertEquals("1", response.get(0).getRegionId());
-        assertThat(response.get(0).getDescription()).isEqualToIgnoringCase("London");
-
+        assertEquals("London", response.get(0).getDescription());
         assertNull(response.get(0).getWelshDescription());
         if (expectedRegions == 2) {
             assertEquals("2", response.get(1).getRegionId());
-            assertThat(response.get(1).getDescription()).isEqualToIgnoringCase("Midlands");
+            assertEquals("Midlands", response.get(1).getDescription());
             assertNull(response.get(1).getWelshDescription());
         }
     }


### PR DESCRIPTION
Adding equals ignore case in functional test 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
