### PR TITLE
DTSRD-261: Location endpoint throws 500 instead of 400 with missing param

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/advice/ExceptionMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/advice/ExceptionMapper.java
@@ -106,6 +106,11 @@ public class ExceptionMapper {
         return errorDetailsResponseEntity(ex, BAD_REQUEST, ex.getMessage());
     }
 
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<Object> handleMissingServletRequestParameterException(Exception ex) {
+        return errorDetailsResponseEntity(ex, BAD_REQUEST, ex.getMessage());
+    }
+
     private String getTimeStamp() {
         return new SimpleDateFormat("dd-MM-yyyy HH:mm:ss.SSS", Locale.ENGLISH).format(new Date());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSRD-261


### Change description ###
It's been observed in AAT that when http://rd-location-ref-api-aat.service.core-compute-aat.internal/refdata/location/court-venues/venue-search is called without specifying the search-string param, the service throws a 500 error instead of a 400 error


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
