### PR TITLE
DTSRD-261: tests

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesBySearchStringIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesBySearchStringIntegrationTest.java
@@ -45,6 +45,20 @@ class RetrieveCourtVenuesBySearchStringIntegrationTest extends LrdAuthorizationE
         responseVerification(new ArrayList<>(Arrays.asList(response)));
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRetrieveCourtVenues_For_NullSearchString_WithStatusCode_400()
+        throws JsonProcessingException {
+        final var response = (LrdCourtVenueResponse[])
+            lrdApiClient.findCourtVenuesBySearchString(
+                "",
+                LrdCourtVenueResponse[].class,
+                path
+            );
+
+        assertEquals(0,response.length);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"?search-string=Stoke-on-Trent", "?search-string=Stoke-", "?search-string=stoke-on",
         "?search-string=stoke-on-"})

--- a/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesBySearchStringIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesBySearchStringIntegrationTest.java
@@ -47,16 +47,16 @@ class RetrieveCourtVenuesBySearchStringIntegrationTest extends LrdAuthorizationE
 
     @Test
     @SuppressWarnings("unchecked")
-    void shouldRetrieveCourtVenues_For_NullSearchString_WithStatusCode_400()
+    void shouldReturn400_WhenSearchStringIsEmpty()
         throws JsonProcessingException {
-        final var response = (LrdCourtVenueResponse[])
+        Map<String, Object> errorResponseMap = (Map<String, Object>)
             lrdApiClient.findCourtVenuesBySearchString(
                 "",
-                LrdCourtVenueResponse[].class,
+                ErrorResponse.class,
                 path
             );
 
-        assertEquals(0,response.length);
+        assertNotNull(errorResponseMap);
     }
 
     @ParameterizedTest

--- a/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesBySearchStringIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenuesBySearchStringIntegrationTest.java
@@ -57,6 +57,7 @@ class RetrieveCourtVenuesBySearchStringIntegrationTest extends LrdAuthorizationE
             );
 
         assertNotNull(errorResponseMap);
+        assertThat(errorResponseMap).containsEntry(HTTP_STATUS_STR, HttpStatus.BAD_REQUEST);
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueControllerTest.java
@@ -211,6 +211,12 @@ class LrdCourtVenueControllerTest {
             lrdCourtVenueController.retrieveCourtVenuesBySearchString("ABC", ",1,2,", null, null, null, null));
     }
 
+    @Test
+    void testGetCourtVenuesBySearchStringWithEmptyString() {
+        assertThrows(InvalidRequestException.class, () ->
+            lrdCourtVenueController.retrieveCourtVenuesBySearchString("", null, null, null, null, null));
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"?search-string=abc--", "?search-string=ab__c", "?search-string=___c",
         "?search-string=___", "?search-string=@@@", "?search-string=---", "?search-string='''",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSRD-261


### Change description ###
It's been observed in AAT that when [http://rd-location-ref-api-aat.service.core-compute-aat.internal/refdata/location/court-venues/venue-search](http://rd-location-ref-api-aat.service.core-compute-aat.internal/refdata/location/court-venues/venue-search?court_type_id=14&location_type=CIC) is called without specifying the search-string param, the service throws a 500 error instead of a 400 error.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
