### PR TITLE
DTSRD-3580 Jenkins Test Reports to Publish on Failure

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -77,7 +77,7 @@ withPipeline(type, product, component) {
     env.TEST_URL = "http://rd-location-ref-api-aat.aat.platform.hmcts.net"
   }
 
-  afterSuccess('sonarscan') {
+  afterAlways('sonarscan') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -97,7 +97,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-  afterSuccess('smoketest:preview') {
+  afterAlways('smoketest:preview') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -108,7 +108,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-  afterSuccess('smoketest:aat') {
+  afterAlways('smoketest:aat') {
         publishHTML target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: true,
@@ -119,7 +119,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-  afterSuccess('functionalTest:aat') {
+  afterAlways('functionalTest:aat') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -131,7 +131,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-  afterSuccess('functionalTest:preview') {
+  afterAlways('functionalTest:preview') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
         publishHTML target: [
             allowMissing         : true,
@@ -143,7 +143,7 @@ withPipeline(type, product, component) {
         ]
     }
 
-  afterSuccess('pact-provider-verification') {
+  afterAlways('pact-provider-verification') {
         publishHTML target: [
              allowMissing         : true,
              alwaysLinkToLastBuild: true,

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -61,11 +61,11 @@ withNightlyPipeline(type, product, component) {
   enableFortifyScan()
 
 
-  afterSuccess('fortify-scan') {
+  afterAlways('fortify-scan') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
   }
 
-  afterSuccess('mutationTest') {
+  afterAlways('mutationTest') {
     publishHTML target: [
       allowMissing         : true,
       alwaysLinkToLastBuild: true,
@@ -76,7 +76,7 @@ withNightlyPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('fullFunctionalTest') {
+  afterAlways('fullFunctionalTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
     publishHTML target: [


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSRD-3580

### Change description ###
Jenkins Test Reports to Publish on Failure - afterSuccess() replaced with afterAlways() for all reports in Jenkinsfile_CNP and nightly


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
