### PR TITLE
PR to fix the PACT provider tests

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/lrdapi/provider/LrdApiProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/lrdapi/provider/LrdApiProviderTest.java
@@ -289,6 +289,7 @@ public class LrdApiProviderTest {
         when(courtVenueRepository.findByRegionIdWithOpenCourtStatus(anyString())).thenReturn(courtVenues);
         when(courtVenueRepository.findAll()).thenReturn(courtVenues);
         when(courtVenueRepository.findByCourtVenueNameOrSiteName(anyString())).thenReturn(courtVenues);
+        when(courtVenueRepository.findByCourtTypeIdAndEpimmsIdWithOpenCourtStatus(anyList(), anyString())).thenReturn(courtVenues);
     }
 
     @State({"Court Venues exist for the search string provided"})


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

This PR calls the method "findByCourtTypeIdAndEpimmsIdWithOpenCourtStatus" as part of the pact provider tests, so the pcs_api consumer tests can be verified successfully.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
