### PR TITLE
DTSRD-5698 Swagger updates to retrieveCourtVenuesByServiceCode API

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueController.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueController.java
@@ -67,6 +67,8 @@ import static uk.gov.hmcts.reform.lrdapi.util.ValidationUtils.validateSearchStri
 @Slf4j
 public class LrdCourtVenueController {
 
+    private static final String WARNING_COURT_VENUE_ID = "&#9888; **Note: the `court_venue_id` property returned "
+        + "should not be used: as it is an internal value that may change.**";
 
     @Value("${loggingComponentName}")
     private String loggingComponentName;
@@ -166,13 +168,12 @@ public class LrdCourtVenueController {
 
     @Operation(
         summary = "This API will retrieve Court Venues for given Service Code",
-        description = "No roles required to access this API",
+        description = "No roles required to access this API<br/><br/>" + WARNING_COURT_VENUE_ID,
         security = {
             @SecurityRequirement(name = "ServiceAuthorization"),
             @SecurityRequirement(name = "Authorization")
         }
     )
-
     @ApiResponse(
             responseCode = "200",
             description = "Successfully retrieved list of Court Venues for given Service Code",
@@ -198,7 +199,6 @@ public class LrdCourtVenueController {
             description = "Internal Server Error",
             content = @Content
         )
-
     @GetMapping(
         path = "/services",
         produces = APPLICATION_JSON_VALUE


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSRD-5698](https://tools.hmcts.net/jira/browse/DTSRD-5698) _"LRD Court Venue - Updates to retrieveCourtVenues API - deprecate court_type parameter"_

### Change description ###

Updates to retrieveCourtVenuesByServiceCode API - swagger warning for `court_venue_id`.

> NB: The feature PR/branch for these changes is:
> * #1110 
>
> This PR has been re-positioned behind PR for [DTSRD-5700](https://tools.hmcts.net/jira/browse/DTSRD-5700):
> * #1107 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
