### PR TITLE
DTSRD-5697-1.Changing validation to accomodate both service id and courttype id if epims id is null 

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenueDetailsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenueDetailsFunctionalTest.java
@@ -196,6 +196,20 @@ class RetrieveCourtVenueDetailsFunctionalTest extends AuthorizationFunctionalTes
 
     @Test
     @ToggleEnable(mapKey = mapKey, withFeature = true)
+    void shouldRetrieveCourtVenues_For_ServiceCode_And_CourtType_Without_Epimms_WithStatusCode_200() {
+        final var response = (LrdCourtVenueResponse[])
+            lrdApiClient.retrieveResponseForGivenRequest(HttpStatus.OK, "?service_code=AAA6&court_type_id=999",
+                                                         LrdCourtVenueResponse[].class, path);
+
+        assertThat(response).isNotEmpty();
+        boolean isEveryServiceCodeMatched = Arrays
+            .stream(response)
+            .allMatch(venue -> "AAA6".equalsIgnoreCase(venue.getServiceCode()));
+        assertTrue(isEveryServiceCodeMatched);
+    }
+
+    @Test
+    @ToggleEnable(mapKey = mapKey, withFeature = true)
     void shouldRetrieveCourtVenues_For_Given_Cluster_Id_WithStatusCode_200() throws JsonProcessingException {
         final var response = (LrdCourtVenueResponse[])
             lrdApiClient.retrieveResponseForGivenRequest(HttpStatus.OK, "?cluster_id=8",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenueDetailsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenueDetailsIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.lrdapi.controllers.constants.ErrorConstants.EMPTY_RESULT_DATA_ACCESS;
 import static uk.gov.hmcts.reform.lrdapi.controllers.constants.ErrorConstants.INVALID_REQUEST_EXCEPTION;
+import static uk.gov.hmcts.reform.lrdapi.controllers.constants.LocationRefConstants.NO_COURT_VENUES_FOUND_FOR_FOR_EPIMMS_ID;
 import static uk.gov.hmcts.reform.lrdapi.controllers.constants.LocationRefConstants.ONLY_ONE_PARAM_REQUIRED_COURT_VENUE;
 
 @WithTags({@WithTag("testType:Integration")})
@@ -631,6 +632,23 @@ class RetrieveCourtVenueDetailsIntegrationTest extends LrdAuthorizationEnabledIn
         assertEquals("AAA6", venueResponse.getServiceCode());
         assertEquals("17", venueResponse.getCourtTypeId());
         assertEquals("123456789", venueResponse.getEpimmsId());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void retrieveCourtVenues_WithEpimmsIdAndServiceCodeAndCourtTypeId_WhenFiltersDoNotMatch_ShouldReturn404()
+        throws JsonProcessingException {
+
+        Map<String, Object> errorResponseMap = (Map<String, Object>)
+            lrdApiClient.retrieveResponseForGivenRequest("?service_code=BFA1&epimms_id=123456789&court_type_id=999",
+                                                         ErrorResponse.class, path);
+
+        assertNotNull(errorResponseMap);
+        assertThat(errorResponseMap).containsEntry(HTTP_STATUS_STR, HttpStatus.NOT_FOUND);
+        ErrorResponse errorResponse = (ErrorResponse) errorResponseMap.get("response_body");
+        assertEquals(EMPTY_RESULT_DATA_ACCESS.getErrorMessage(), errorResponse.getErrorMessage());
+        assertEquals(String.format(NO_COURT_VENUES_FOUND_FOR_FOR_EPIMMS_ID, "[123456789]"),
+                     errorResponse.getErrorDescription());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenueDetailsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/lrdapi/RetrieveCourtVenueDetailsIntegrationTest.java
@@ -603,6 +603,20 @@ class RetrieveCourtVenueDetailsIntegrationTest extends LrdAuthorizationEnabledIn
 
     @Test
     @SuppressWarnings("unchecked")
+    void retrieveCourtVenues_WithServiceCodeAndCourtTypeIdWithoutEpimms_UsesServiceCode() throws
+        JsonProcessingException {
+
+        final var response = (List<LrdCourtVenueResponse>)
+            lrdApiClient.retrieveCourtVenueResponseForGivenRequest("?service_code=AAA6&court_type_id=999",
+                                                                   LrdCourtVenueResponse[].class, path);
+
+        assertThat(response).isNotEmpty().hasSize(4);
+        assertTrue(response.stream().allMatch(venue -> "AAA6".equals(venue.getServiceCode())));
+        assertTrue(response.stream().noneMatch(venue -> "999".equals(venue.getCourtTypeId())));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     void retrieveCourtVenues_WithEpimmsIdAndServiceCodeAndCourtTypeId_200() throws JsonProcessingException {
 
         final var response = (List<LrdCourtVenueResponse>)

--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueController.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueController.java
@@ -145,8 +145,8 @@ public class LrdCourtVenueController {
                                       String.valueOf(regionId), String.valueOf(clusterId), courtVenueName
             );
         } else {
-             String eitherServiceCodeOrCourtTypeId = StringUtils.isNotBlank(serviceCode) ?
-                 serviceCode : String.valueOf(courtTypeId);
+            String eitherServiceCodeOrCourtTypeId = StringUtils.isNotBlank(serviceCode)
+                ? serviceCode : String.valueOf(courtTypeId);
 
             checkIfMultipleValuePresentForVenue(ONLY_ONE_PARAM_REQUIRED_COURT_VENUE, epimmsIds,
                                                 eitherServiceCodeOrCourtTypeId, String.valueOf(regionId),

--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueController.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueController.java
@@ -145,8 +145,11 @@ public class LrdCourtVenueController {
                                       String.valueOf(regionId), String.valueOf(clusterId), courtVenueName
             );
         } else {
+             String eitherServiceCodeOrCourtTypeId = StringUtils.isNotBlank(serviceCode) ?
+                 serviceCode : String.valueOf(courtTypeId);
+
             checkIfMultipleValuePresentForVenue(ONLY_ONE_PARAM_REQUIRED_COURT_VENUE, epimmsIds,
-                String.valueOf(courtTypeId),  String.valueOf(serviceCode), String.valueOf(regionId),
+                                                eitherServiceCodeOrCourtTypeId, String.valueOf(regionId),
                                                 String.valueOf(clusterId), courtVenueName);
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/repository/CourtVenueRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/repository/CourtVenueRepository.java
@@ -77,4 +77,9 @@ public interface CourtVenueRepository extends JpaRepository<CourtVenue, Long> {
         + "where upper(cv.serviceCode) = upper(:serviceCode)")
     List<CourtVenue> findByServiceCode(String serviceCode);
 
+    @Query(value = "select cv from court_venue cv LEFT JOIN FETCH cv.courtType"
+        + " LEFT JOIN FETCH cv.cluster LEFT JOIN FETCH cv.region "
+        + "where upper(cv.serviceCode) = upper(:serviceCode) "
+        + "and cv.courtStatus='Open'")
+    List<CourtVenue> findByServiceCodeWithOpenCourtStatus(String serviceCode);
 }

--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImpl.java
@@ -162,13 +162,22 @@ public class CourtVenueServiceImpl implements CourtVenueService {
             );
 
         }
-
         if (isNotBlank(epimmsIds)) {
             return getLrdCourtVenueResponses(
                 retrieveCourtVenuesByEpimmsId(epimmsIds),
                 courtVenueRequestParam
             );
 
+        }
+        if (isNotEmpty(serviceCode)) {
+            log.info("{} : Obtaining court venues for service codes: {}", loggingComponentName, serviceCode);
+
+            List<LrdCourtVenueResponse> lrdCourtVenueResponse =
+                getAllCourtVenues(
+                    () -> courtVenueRepository.findByServiceCode(serviceCode), serviceCode,
+                    NO_COURT_VENUES_FOUND_FOR_SERVICE_CODE
+                );
+            return getLrdCourtVenueResponses(lrdCourtVenueResponse, courtVenueRequestParam);
         }
         if (isNotEmpty(courtTypeId)) {
             log.info("{} : Obtaining court venues for court type id: {}", loggingComponentName, courtTypeId);
@@ -178,16 +187,6 @@ public class CourtVenueServiceImpl implements CourtVenueService {
                     () -> courtVenueRepository.findByCourtTypeIdWithOpenCourtStatus(courtTypeId.toString()),
                     courtTypeId.toString(),
                     NO_COURT_VENUES_FOUND_FOR_COURT_TYPE_ID
-                );
-            return getLrdCourtVenueResponses(lrdCourtVenueResponse, courtVenueRequestParam);
-        }
-        if (isNotEmpty(serviceCode)) {
-            log.info("{} : Obtaining court venues for service codes: {}", loggingComponentName, serviceCode);
-
-            List<LrdCourtVenueResponse> lrdCourtVenueResponse =
-                getAllCourtVenues(
-                    () -> courtVenueRepository.findByServiceCode(serviceCode), serviceCode,
-                    NO_COURT_VENUES_FOUND_FOR_SERVICE_CODE
                 );
             return getLrdCourtVenueResponses(lrdCourtVenueResponse, courtVenueRequestParam);
         }

--- a/src/main/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImpl.java
@@ -174,7 +174,7 @@ public class CourtVenueServiceImpl implements CourtVenueService {
 
             List<LrdCourtVenueResponse> lrdCourtVenueResponse =
                 getAllCourtVenues(
-                    () -> courtVenueRepository.findByServiceCode(serviceCode), serviceCode,
+                    () -> courtVenueRepository.findByServiceCodeWithOpenCourtStatus(serviceCode), serviceCode,
                     NO_COURT_VENUES_FOUND_FOR_SERVICE_CODE
                 );
             return getLrdCourtVenueResponses(lrdCourtVenueResponse, courtVenueRequestParam);

--- a/src/test/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/lrdapi/controllers/LrdCourtVenueControllerTest.java
@@ -183,6 +183,39 @@ class LrdCourtVenueControllerTest {
     }
 
     @Test
+    void testGetCourtVenues_WithServiceCodeAndCourtTypeWithoutEpimms_Returns200() {
+        ResponseEntity<List<LrdCourtVenueResponse>> responseEntity =
+            lrdCourtVenueController.retrieveCourtVenues(
+                null, "ABC1", 13, null, null, null, "Y",
+                "Y", "CTSC", "Y"
+            );
+
+        assertNotNull(responseEntity);
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+        ArgumentCaptor<CourtVenueRequestParam> courtVenueRequestParamCaptr =
+            ArgumentCaptor.forClass(CourtVenueRequestParam.class);
+        ArgumentCaptor<Integer> courtTypeIdCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<String> serviceCodeCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> booleanCaptor = ArgumentCaptor.forClass(Boolean.class);
+
+        verify(courtVenueServiceMock, times(1)).retrieveCourtVenueDetails(
+            isNull(),
+            courtTypeIdCaptor.capture(),
+            serviceCodeCaptor.capture(),
+            isNull(),
+            isNull(),
+            isNull(),
+            booleanCaptor.capture(),
+            courtVenueRequestParamCaptr.capture()
+        );
+        assertEquals(13, courtTypeIdCaptor.getValue());
+        assertEquals("ABC1", serviceCodeCaptor.getValue());
+        assertThat(booleanCaptor.getValue()).isFalse();
+        assertNotNull(courtVenueRequestParamCaptr.getValue());
+    }
+
+    @Test
     void testGetCourtVenues_WithMultipleParams_Returns400() {
         Exception exception = assertThrows(InvalidRequestException.class, () ->
             lrdCourtVenueController.retrieveCourtVenues("12345", null, null, 12,

--- a/src/test/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImplTest.java
@@ -350,7 +350,7 @@ class CourtVenueServiceImplTest {
     @Test
     void test_RetrieveCourtVenuesByServiceCode() {
 
-        when(courtVenueRepository.findByServiceCode(anyString())).thenReturn(prepareCourtVenue());
+        when(courtVenueRepository.findByServiceCodeWithOpenCourtStatus(anyString())).thenReturn(prepareCourtVenue());
 
         List<LrdCourtVenueResponse> courtVenueResponses =
             courtVenueService
@@ -360,7 +360,7 @@ class CourtVenueServiceImplTest {
         LrdCourtVenueResponse courtVenueResponse = courtVenueResponses.get(0);
 
         verifySingleResponse(courtVenueResponse);
-        verify(courtVenueRepository, times(1)).findByServiceCode("AAA6");
+        verify(courtVenueRepository, times(1)).findByServiceCodeWithOpenCourtStatus("AAA6");
         verify(courtVenueRepository, times(0)).findByEpimmsIdIn(anyList());
         verify(courtVenueRepository, times(0)).findByRegionIdWithOpenCourtStatus(anyString());
         verify(courtVenueRepository, times(0)).findByClusterIdWithOpenCourtStatus(anyString());
@@ -373,7 +373,7 @@ class CourtVenueServiceImplTest {
     @Test
     void test_RetrieveCourtVenuesByServiceCode_WhenCourtTypeAlsoProvided() {
 
-        when(courtVenueRepository.findByServiceCode(anyString())).thenReturn(prepareCourtVenue());
+        when(courtVenueRepository.findByServiceCodeWithOpenCourtStatus(anyString())).thenReturn(prepareCourtVenue());
 
         List<LrdCourtVenueResponse> courtVenueResponses =
             courtVenueService
@@ -383,7 +383,7 @@ class CourtVenueServiceImplTest {
         LrdCourtVenueResponse courtVenueResponse = courtVenueResponses.get(0);
 
         verifySingleResponse(courtVenueResponse);
-        verify(courtVenueRepository, times(1)).findByServiceCode("AAA6");
+        verify(courtVenueRepository, times(1)).findByServiceCodeWithOpenCourtStatus("AAA6");
         verify(courtVenueRepository, times(0)).findByEpimmsIdIn(anyList());
         verify(courtVenueRepository, times(0)).findByRegionIdWithOpenCourtStatus(anyString());
         verify(courtVenueRepository, times(0)).findByClusterIdWithOpenCourtStatus(anyString());
@@ -485,7 +485,7 @@ class CourtVenueServiceImplTest {
 
     @Test
     void test_RetrieveCourtVenuesByServiceCode_NotFound() {
-        when(courtVenueRepository.findByServiceCode(anyString())).thenReturn(null);
+        when(courtVenueRepository.findByServiceCodeWithOpenCourtStatus(anyString())).thenReturn(null);
         assertThrows(ResourceNotFoundException.class, () -> courtVenueService
             .retrieveCourtVenueDetails("", null, "AAA6", null, null, null,
                                        false, courtVenueRequestParam));
@@ -496,7 +496,7 @@ class CourtVenueServiceImplTest {
         verify(courtVenueRepository, times(0)).findAll();
         verify(courtVenueRepository, times(0)).findAllWithOpenCourtStatus();
         verify(courtVenueRepository, times(0)).findByCourtTypeIdWithOpenCourtStatus(anyString());
-        verify(courtVenueRepository, times(1)).findByServiceCode("AAA6");
+        verify(courtVenueRepository, times(1)).findByServiceCodeWithOpenCourtStatus("AAA6");
         verify(courtVenueRepository, times(0)).findByCourtVenueNameOrSiteName(anyString());
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/lrdapi/service/impl/CourtVenueServiceImplTest.java
@@ -371,6 +371,29 @@ class CourtVenueServiceImplTest {
     }
 
     @Test
+    void test_RetrieveCourtVenuesByServiceCode_WhenCourtTypeAlsoProvided() {
+
+        when(courtVenueRepository.findByServiceCode(anyString())).thenReturn(prepareCourtVenue());
+
+        List<LrdCourtVenueResponse> courtVenueResponses =
+            courtVenueService
+                .retrieveCourtVenueDetails("", 17, "AAA6", null, null, null,
+                                           false, courtVenueRequestParam);
+
+        LrdCourtVenueResponse courtVenueResponse = courtVenueResponses.get(0);
+
+        verifySingleResponse(courtVenueResponse);
+        verify(courtVenueRepository, times(1)).findByServiceCode("AAA6");
+        verify(courtVenueRepository, times(0)).findByEpimmsIdIn(anyList());
+        verify(courtVenueRepository, times(0)).findByRegionIdWithOpenCourtStatus(anyString());
+        verify(courtVenueRepository, times(0)).findByClusterIdWithOpenCourtStatus(anyString());
+        verify(courtVenueRepository, times(0)).findAll();
+        verify(courtVenueRepository, times(0)).findAllWithOpenCourtStatus();
+        verify(courtVenueRepository, times(0)).findByCourtTypeIdWithOpenCourtStatus(anyString());
+        verify(courtVenueRepository, times(0)).findByCourtVenueNameOrSiteName(anyString());
+    }
+
+    @Test
     void test_RetrieveCourtVenuesByCourtVenueName() {
 
         when(courtVenueRepository.findByCourtVenueNameOrSiteName(anyString())).thenReturn(prepareCourtVenue());


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSRD-5697](https://tools.hmcts.net/jira/browse/DTSRD-5697) _"LRD Court Venue - Updates to retrieveCourtVenues API for new model"_


### Change description ###

DTSRD-5697-1.Changing validation to accomodate both service id and courttype id if epims id is null and will fetch based on service code

> NB: The feature PR/branch for these changes is:
> * https://github.com/hmcts/rd-location-ref-api/pull/1110

